### PR TITLE
[codex] align latent factor training protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `ml4t-models` will be documented in this file.
 
+## 0.1.0a4
+
+- Aligned conditional autoencoder training with shuffled mini-batches, BatchNorm hidden layers,
+  validation-best checkpoints, and per-member extraction.
+- Aligned stochastic discount factor checkpoints with phase-local training, validation-best
+  tracking, and legacy checkpoint-label compatibility.
+- Kept IPCA factor extraction consistent with the final normalized loading matrix.
+
 ## 0.1.0a1
 
 - Declared Python 3.14 support in package metadata.

--- a/src/ml4t/models/__init__.py
+++ b/src/ml4t/models/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 
-__version__ = "0.1.0a3"
+__version__ = "0.1.0a4"
 
 from ml4t.models.api import (
     AssetMapper,

--- a/src/ml4t/models/_internal/cae_nn.py
+++ b/src/ml4t/models/_internal/cae_nn.py
@@ -17,6 +17,7 @@ class BetaNetwork(nn.Module):
         in_features = n_characteristics
         for units in hidden_units:
             layers.append(nn.Linear(in_features, units))
+            layers.append(nn.BatchNorm1d(units))
             layers.append(nn.ReLU())
             in_features = units
         layers.append(nn.Linear(in_features, n_factors))

--- a/src/ml4t/models/configs/latent_factor.py
+++ b/src/ml4t/models/configs/latent_factor.py
@@ -62,6 +62,7 @@ class CAEConfig(LatentFactorConfig):
     default_checkpoint: int | None = None
     lr: float = 1e-3
     lambda_l1: float = 1e-4
+    batch_size: int = 10_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,7 +81,7 @@ class StochasticDiscountFactorConfig(BaseModelConfig):
     n_epochs_cond: int = 1024
     checkpoint_interval: int | None = None
     checkpoint_epochs: tuple[int, ...] = ()
-    default_checkpoint: int | None = None
+    default_checkpoint: int | tuple[str, int] | None = None
     expected_return_mapper: str = "linear"
     beta_state_dim: int = 4
     beta_hidden_dim: int = 64

--- a/src/ml4t/models/latent_factors/cae.py
+++ b/src/ml4t/models/latent_factors/cae.py
@@ -26,19 +26,33 @@ class CAEModel(BaseLatentFactorModel[CAEConfig]):
         self._n_characteristics: int | None = None
         self._n_instruments: int | None = None
         self._history: tuple[dict[str, float | str], ...] = ()
+        self._fit_default_checkpoint: int | None = None
 
     @property
     def available_checkpoints(self) -> tuple[int, ...]:
         return tuple(sorted(self._checkpoint_states))
 
-    def fit(self, batch: PanelBatch) -> FitSummary:
+    def fit(
+        self,
+        batch: PanelBatch,
+        *,
+        validation_batch: PanelBatch | None = None,
+        patience: int = 50,
+    ) -> FitSummary:
         cross_section = _require_cross_section(batch)
         if cross_section.returns is None:
             raise ValueError("CAE requires returns in the training batch")
+        validation_cross_section = (
+            _require_cross_section(validation_batch) if validation_batch is not None else None
+        )
+        if validation_cross_section is not None and validation_cross_section.returns is None:
+            raise ValueError("validation_batch requires returns for CAE validation loss")
         if self.config.n_factors < 1:
             raise ValueError(f"n_factors must be positive; got {self.config.n_factors}")
         if self.config.n_ensemble < 1:
             raise ValueError(f"n_ensemble must be positive; got {self.config.n_ensemble}")
+        if self.config.batch_size < 1:
+            raise ValueError(f"batch_size must be positive; got {self.config.batch_size}")
         if self.config.task_type == "classification" and cross_section.factor_returns is None:
             raise ValueError(
                 "Classification CAE requires factor_returns for managed-portfolio construction"
@@ -72,9 +86,34 @@ class CAEModel(BaseLatentFactorModel[CAEConfig]):
             device=device,
         )
         mask_train = _resolve_mask(cross_section)
+        flat_chars, flat_portfolios, flat_returns = _flatten_training_panel(
+            torch=torch,
+            characteristics=chars_train,
+            managed_portfolios=portfolios_train,
+            returns=returns_train,
+            mask=mask_train,
+            device=device,
+        )
+        if int(flat_returns.shape[0]) == 0:
+            raise ValueError("CAE received no valid training observations")
+
+        validation_tensors = None
+        if validation_cross_section is not None:
+            validation_portfolio_returns = _portfolio_returns(validation_cross_section)
+            assert validation_portfolio_returns is not None
+            validation_tensors = _prepare_validation_tensors(
+                torch=torch,
+                cross_section=validation_cross_section,
+                managed_portfolios=_compute_managed_portfolios(
+                    characteristics=validation_cross_section.characteristics,
+                    returns=validation_portfolio_returns,
+                ),
+                device=device,
+            )
 
         self._checkpoint_states = defaultdict(list)
-        loss_sums = dict.fromkeys(checkpoint_epochs, 0.0)
+        loss_sums: dict[int, float] = dict.fromkeys(checkpoint_epochs, 0.0)
+        val_best_losses: list[float] = []
 
         for ensemble_idx in range(self.config.n_ensemble):
             seed = self.config.seed + ensemble_idx
@@ -89,22 +128,22 @@ class CAEModel(BaseLatentFactorModel[CAEConfig]):
             ).to(device)
             optimizer = torch.optim.Adam(model.parameters(), lr=self.config.lr)
 
+            best_val_loss = float("inf")
+            best_state: dict[str, Any] | None = None
+            patience_counter = 0
             for epoch in range(1, self.config.n_epochs + 1):
                 model.train()
                 epoch_loss = 0.0
                 n_batches = 0
+                order = torch.randperm(flat_returns.shape[0], device=device)
 
-                for date_idx in range(cross_section.n_periods):
-                    valid = (
-                        mask_train[date_idx] & torch.isfinite(returns_train[date_idx]).cpu().numpy()
-                    )
-                    if not valid.any():
+                for start in range(0, int(flat_returns.shape[0]), self.config.batch_size):
+                    batch_idx = order[start : start + self.config.batch_size]
+                    if batch_idx.numel() == 1 and self.config.hidden_units:
                         continue
 
-                    features_t = chars_train[date_idx, valid]
-                    target_t = returns_train[date_idx, valid]
-                    portfolios_t = portfolios_train[date_idx, valid]
-                    scores_t = model(features_t, portfolios_t)
+                    scores_t = model(flat_chars[batch_idx], flat_portfolios[batch_idx])
+                    target_t = flat_returns[batch_idx]
 
                     if self.config.task_type == "classification":
                         main_loss = torch.nn.functional.binary_cross_entropy_with_logits(
@@ -127,28 +166,63 @@ class CAEModel(BaseLatentFactorModel[CAEConfig]):
                     self._checkpoint_states[epoch].append(_cpu_state_dict(model))
                     loss_sums[epoch] += mean_loss
 
+                if validation_tensors is not None:
+                    val_loss = _validation_loss(
+                        torch=torch,
+                        model=model,
+                        validation_tensors=validation_tensors,
+                        task_type=self.config.task_type,
+                    )
+                    if val_loss < best_val_loss:
+                        best_val_loss = val_loss
+                        best_state = _cpu_state_dict(model)
+                        patience_counter = 0
+                    else:
+                        patience_counter += 1
+                    if patience_counter >= patience:
+                        break
+
+            if best_state is not None:
+                self._checkpoint_states[0].append(best_state)
+                val_best_losses.append(best_val_loss)
+
         history: list[dict[str, float | str]] = []
         for epoch in checkpoint_epochs:
+            if epoch in self._checkpoint_states:
+                history.append(
+                    {
+                        "epoch": float(epoch),
+                        "train_loss": loss_sums[epoch] / self.config.n_ensemble,
+                    }
+                )
+        if val_best_losses:
             history.append(
                 {
-                    "epoch": float(epoch),
-                    "train_loss": loss_sums[epoch] / self.config.n_ensemble,
+                    "epoch": 0.0,
+                    "checkpoint": "validation_best",
+                    "val_loss": float(np.mean(val_best_losses)),
                 }
             )
         self._history = tuple(history)
         self._asset_ids = cross_section.asset_ids
         self._n_characteristics = cross_section.characteristics.shape[2]
         self._n_instruments = managed_portfolios.shape[2]
+        self._fit_default_checkpoint = (
+            0 if val_best_losses else _default_checkpoint(self.config, self.available_checkpoints)
+        )
         self._mark_fitted()
 
         return FitSummary(
             converged=True,
             train_metrics={
                 "n_train_periods": float(cross_section.n_periods),
-                "n_checkpoints": float(len(checkpoint_epochs)),
+                "n_checkpoints": float(len(self.available_checkpoints)),
                 "n_ensemble": float(self.config.n_ensemble),
             },
-            best_epoch=_default_checkpoint(self.config, checkpoint_epochs),
+            val_metrics=(
+                {"best_val_loss": float(np.mean(val_best_losses))} if val_best_losses else {}
+            ),
+            best_epoch=self._fit_default_checkpoint,
             history=self._history,
             notes=("Neural betas and linear factors stored at configurable checkpoints.",),
         )
@@ -177,7 +251,7 @@ class CAEModel(BaseLatentFactorModel[CAEConfig]):
         nn = _import_cae_nn()
         selected_checkpoint = _select_checkpoint(
             checkpoint=checkpoint,
-            configured_default=self.config.default_checkpoint,
+            configured_default=self._fit_default_checkpoint,
             available=self.available_checkpoints,
         )
         device = resolve_device(torch, self.config.device)
@@ -236,6 +310,80 @@ class CAEModel(BaseLatentFactorModel[CAEConfig]):
                 "available_checkpoints": self.available_checkpoints,
             },
         )
+
+    def extract_per_member(
+        self,
+        batch: PanelBatch,
+        *,
+        checkpoint: int | None = None,
+    ) -> list[LatentFactorState]:
+        cross_section = _require_cross_section(batch)
+        if (
+            not self.is_fitted
+            or self._n_characteristics is None
+            or self._n_instruments is None
+            or not self._checkpoint_states
+        ):
+            raise RuntimeError("CAE model must be fitted before extract_per_member()")
+        if cross_section.characteristics.shape[2] != self._n_characteristics:
+            raise ValueError(
+                "characteristics feature dimension does not match fitted CAE model; "
+                f"expected {self._n_characteristics}, got {cross_section.characteristics.shape[2]}"
+            )
+
+        torch = import_torch()
+        nn = _import_cae_nn()
+        selected_checkpoint = _select_checkpoint(
+            checkpoint=checkpoint,
+            configured_default=self._fit_default_checkpoint,
+            available=self.available_checkpoints,
+        )
+        device = resolve_device(torch, self.config.device)
+        mask = _resolve_mask(cross_section)
+        portfolio_returns = _portfolio_returns(cross_section)
+        managed_portfolios = None
+        if portfolio_returns is not None:
+            managed_portfolios = _compute_managed_portfolios(
+                characteristics=cross_section.characteristics,
+                returns=portfolio_returns,
+            )
+
+        states: list[LatentFactorState] = []
+        for member_idx, state_dict in enumerate(self._checkpoint_states[selected_checkpoint]):
+            model = nn.ConditionalAutoencoder(
+                n_characteristics=self._n_characteristics,
+                n_instruments=self._n_instruments,
+                n_factors=self.config.n_factors,
+                hidden_units=self.config.hidden_units,
+            ).to(device)
+            model.load_state_dict(deepcopy(state_dict))
+            model.eval()
+            asset_betas, factor_returns = _extract_cae_state(
+                torch=torch,
+                model=model,
+                characteristics=cross_section.characteristics,
+                managed_portfolios=managed_portfolios,
+                mask=mask,
+                n_factors=self.config.n_factors,
+                device=device,
+            )
+            states.append(
+                LatentFactorState(
+                    asset_betas=asset_betas,
+                    factor_returns=factor_returns,
+                    checkpoint_epoch=selected_checkpoint,
+                    timestamps=cross_section.timestamps,
+                    asset_ids=cross_section.asset_ids or self._asset_ids,
+                    metadata={
+                        "model_name": self.config.model_name,
+                        "persistent_entities": False,
+                        "task_type": self.config.task_type,
+                        "ensemble_member": member_idx,
+                        "n_ensemble": len(self._checkpoint_states[selected_checkpoint]),
+                    },
+                )
+            )
+        return states
 
 
 def _require_cross_section(batch: PanelBatch) -> CrossSectionBatch:
@@ -304,6 +452,83 @@ def _compute_managed_portfolios(
         np.asarray(characteristics, dtype=np.float64),
         np.asarray(returns, dtype=np.float64),
     )
+
+
+def _flatten_training_panel(
+    *,
+    torch: Any,
+    characteristics: Any,
+    managed_portfolios: Any,
+    returns: Any,
+    mask: np.ndarray,
+    device: Any,
+) -> tuple[Any, Any, Any]:
+    mask_t = torch.as_tensor(mask, dtype=torch.bool, device=device)
+    valid = mask_t & torch.isfinite(returns)
+    return characteristics[valid], managed_portfolios[valid], returns[valid]
+
+
+def _prepare_validation_tensors(
+    *,
+    torch: Any,
+    cross_section: CrossSectionBatch,
+    managed_portfolios: np.ndarray,
+    device: Any,
+) -> tuple[Any, Any, Any, Any]:
+    assert cross_section.returns is not None
+    returns_np = np.asarray(cross_section.returns, dtype=np.float32)
+    mask_np = _resolve_mask(cross_section)
+    if not np.any(mask_np & np.isfinite(returns_np)):
+        raise ValueError("validation_batch contains no valid CAE validation observations")
+    return (
+        torch.as_tensor(
+            np.asarray(cross_section.characteristics, dtype=np.float32),
+            dtype=torch.float32,
+            device=device,
+        ),
+        torch.as_tensor(
+            np.asarray(managed_portfolios, dtype=np.float32),
+            dtype=torch.float32,
+            device=device,
+        ),
+        torch.as_tensor(
+            returns_np,
+            dtype=torch.float32,
+            device=device,
+        ),
+        torch.as_tensor(mask_np, dtype=torch.bool, device=device),
+    )
+
+
+def _validation_loss(
+    *,
+    torch: Any,
+    model: Any,
+    validation_tensors: tuple[Any, Any, Any, Any],
+    task_type: str,
+) -> float:
+    characteristics, managed_portfolios, returns, mask = validation_tensors
+    was_training = model.training
+    model.eval()
+    losses: list[float] = []
+    with torch.no_grad():
+        for date_idx in range(characteristics.shape[0]):
+            valid = mask[date_idx] & torch.isfinite(returns[date_idx])
+            if not bool(valid.any()):
+                continue
+            scores_t = model(characteristics[date_idx, valid], managed_portfolios[date_idx, valid])
+            target_t = returns[date_idx, valid]
+            if task_type == "classification":
+                loss = torch.nn.functional.binary_cross_entropy_with_logits(
+                    scores_t,
+                    target_t.clamp(0.0, 1.0),
+                )
+            else:
+                loss = torch.nn.functional.mse_loss(scores_t, target_t)
+            losses.append(float(loss.item()))
+    if was_training:
+        model.train()
+    return float(np.mean(losses)) if losses else float("inf")
 
 
 def _cpu_state_dict(model: Any) -> dict[str, Any]:

--- a/src/ml4t/models/latent_factors/ipca.py
+++ b/src/ml4t/models/latent_factors/ipca.py
@@ -31,9 +31,7 @@ class IPCAModel(BaseLatentFactorModel[IPCAConfig]):
     @property
     def train_factor_returns(self) -> np.ndarray:
         if self._train_factor_returns is None:
-            raise RuntimeError(
-                "IPCA model must be fitted before train_factor_returns is available"
-            )
+            raise RuntimeError("IPCA model must be fitted before train_factor_returns is available")
         return self._train_factor_returns
 
     def fit(self, batch: PanelBatch) -> FitSummary:
@@ -111,10 +109,8 @@ class IPCAModel(BaseLatentFactorModel[IPCAConfig]):
         else:
             self._fit_iterations = self.config.max_iter
 
-        # Recompute factor history under the final gamma so (gamma,
-        # factor_history) are mutually consistent regardless of convergence
-        # branch. At convergence this is a no-op within tol; at non-convergence
-        # it removes the half-step mismatch otherwise present (KPS §3.1).
+        # Recompute factor history under the final gamma before applying
+        # KPS ΘY normalization.
         for date_idx, (design_t, target_t) in enumerate(
             zip(train_designs, train_targets, strict=True)
         ):
@@ -373,16 +369,16 @@ def _normalize_theta_y(
         chol = eigvecs @ np.diag(np.sqrt(eigvals)) @ eigvecs.T
 
     chol_inv = np.linalg.inv(chol)  # K × K, lower triangular inverse
-    gamma_orthonormal = gamma @ chol_inv.T            # (L, K), Γ'Γ = I_K
+    gamma_orthonormal = gamma @ chol_inv.T  # (L, K), Γ'Γ = I_K
     # In column form `f_new = L^T f`; in row form (factor_history shape (T, K))
     # this becomes `f_new = factor_history @ L = factor_history @ chol`.
-    f_intermediate = factor_history @ chol            # preserves Γ · f product
+    f_intermediate = factor_history @ chol  # preserves Γ · f product
 
     # Step 2: eigendecomp of factor covariance, descending eigenvalues.
     f_cov = (f_intermediate.T @ f_intermediate) / factor_history.shape[0]
     eigvals, eigvecs = np.linalg.eigh(f_cov)
     order = np.argsort(eigvals)[::-1]
-    rotation = eigvecs[:, order]                      # orthonormal K × K
+    rotation = eigvecs[:, order]  # orthonormal K × K
 
     # Step 3: deterministic sign convention. Eigenvectors are unique only up
     # to ±. Pin signs so each column of Γ has a non-negative max-magnitude

--- a/src/ml4t/models/stochastic_discount_factor/base.py
+++ b/src/ml4t/models/stochastic_discount_factor/base.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from ml4t.models.configs import StochasticDiscountFactorConfig
 from ml4t.models.types import CrossSectionBatch, FitSummary, StochasticDiscountFactorState
 
+type SDFCheckpoint = tuple[str, int]
+
 
 class BaseStochasticDiscountFactorModel(ABC):
     """Abstract base for stochastic discount factor models."""
@@ -20,11 +22,17 @@ class BaseStochasticDiscountFactorModel(ABC):
         return self._is_fitted
 
     @property
-    def available_checkpoints(self) -> tuple[int, ...]:
+    def available_checkpoints(self) -> tuple[SDFCheckpoint, ...]:
         return ()
 
     @abstractmethod
-    def fit(self, batch: CrossSectionBatch) -> FitSummary:
+    def fit(
+        self,
+        batch: CrossSectionBatch,
+        *,
+        validation_batch: CrossSectionBatch | None = None,
+        patience: int | None = None,
+    ) -> FitSummary:
         """Fit the stochastic discount factor model on a dated cross-sectional batch."""
 
     @abstractmethod
@@ -32,7 +40,7 @@ class BaseStochasticDiscountFactorModel(ABC):
         self,
         batch: CrossSectionBatch,
         *,
-        checkpoint: int | None = None,
+        checkpoint: SDFCheckpoint | int | None = None,
     ) -> StochasticDiscountFactorState:
         """Extract the structural stochastic discount factor state from a batch."""
 

--- a/src/ml4t/models/stochastic_discount_factor/model.py
+++ b/src/ml4t/models/stochastic_discount_factor/model.py
@@ -10,20 +10,18 @@ import numpy as np
 
 from ml4t.models._internal.latent_factor_utils import (
     resolve_checkpoint_epochs,
-    select_checkpoint_epoch,
 )
 from ml4t.models._internal.torch_runtime import import_torch, resolve_device, seed_torch
 from ml4t.models.configs import StochasticDiscountFactorConfig
 from ml4t.models.stochastic_discount_factor.base import BaseStochasticDiscountFactorModel
 from ml4t.models.types import CrossSectionBatch, FitSummary, StochasticDiscountFactorState
 
-# CPZ best-by-validation checkpoint sentinels. Negative so they never collide
-# with the positive interval-checkpoint grid and never become the extract()
-# default (which is the largest available key, i.e. the final epoch).
-VAL_BEST_LOSS_UNCONDITIONAL = -1
-VAL_BEST_SHARPE_UNCONDITIONAL = -2
-VAL_BEST_LOSS_CONDITIONAL = -3
-VAL_BEST_SHARPE_CONDITIONAL = -4
+SDFCheckpoint = tuple[str, int]
+
+VAL_BEST_LOSS_UNCONDITIONAL: SDFCheckpoint = ("unconditional", 0)
+VAL_BEST_SHARPE_UNCONDITIONAL: SDFCheckpoint = ("unconditional", -1)
+VAL_BEST_LOSS_CONDITIONAL: SDFCheckpoint = ("conditional", 0)
+VAL_BEST_SHARPE_CONDITIONAL: SDFCheckpoint = ("conditional", -1)
 
 
 class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
@@ -31,15 +29,15 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
 
     def __init__(self, config: StochasticDiscountFactorConfig) -> None:
         super().__init__(config)
-        self._checkpoint_states: dict[int, dict[str, dict[str, Any]]] = {}
+        self._checkpoint_states: dict[SDFCheckpoint, dict[str, dict[str, Any]]] = {}
         self._asset_ids: tuple[str, ...] = ()
         self._n_characteristics: int | None = None
         self._n_context_features: int = 0
         self._history: tuple[dict[str, float | str], ...] = ()
 
     @property
-    def available_checkpoints(self) -> tuple[int, ...]:
-        return tuple(sorted(self._checkpoint_states))
+    def available_checkpoints(self) -> tuple[SDFCheckpoint, ...]:
+        return tuple(sorted(self._checkpoint_states, key=_checkpoint_sort_key))
 
     def fit(
         self,
@@ -85,9 +83,8 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
                 device=device,
             )
 
-        # Seed BEFORE constructing the networks so weight initialization is
-        # governed by config.seed (otherwise init draws from the un-seeded
-        # global RNG and SDF results are not reproducible across runs).
+        # Seed before network construction so initialization and training are
+        # reproducible for a fixed configuration.
         seed_torch(torch, self.config.seed, device)
         np.random.seed(self.config.seed)
 
@@ -117,17 +114,15 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
             weight_decay=self.config.weight_decay,
         )
 
-        total_epochs = self.config.n_epochs_unc + self.config.n_epochs_cond
         checkpoint_epochs = tuple(
             resolve_checkpoint_epochs(
-                total_epochs,
+                max(self.config.n_epochs_unc, self.config.n_epochs_cond),
                 checkpoint_interval=self.config.checkpoint_interval,
                 checkpoint_epochs=list(self.config.checkpoint_epochs) or None,
             )
         )
         self._checkpoint_states = defaultdict(dict)
         history: list[dict[str, float | str]] = []
-        sdf_epoch = 0
 
         val_tensors = (
             _prepare_sdf_tensors(validation_batch, torch, device)
@@ -141,7 +136,6 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
         epochs_since_improve = 0
 
         for phase_epoch in range(1, self.config.n_epochs_unc + 1):
-            sdf_epoch += 1
             stochastic_discount_factor_net.train()
             weights, _ = stochastic_discount_factor_net(
                 asset_features,
@@ -158,14 +152,14 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
             sharpe = nn.compute_sharpe(stochastic_discount_factor_values)
             history.append(
                 {
-                    "epoch": float(sdf_epoch),
+                    "epoch": float(phase_epoch),
                     "phase": "unconditional",
                     "train_loss": float(loss.item()),
                     "train_sharpe": float(sharpe.item()),
                 }
             )
             self._maybe_store_checkpoint(
-                epoch=sdf_epoch,
+                phase="unconditional",
                 phase_epoch=phase_epoch,
                 checkpoint_epochs=checkpoint_epochs,
                 stochastic_discount_factor_net=stochastic_discount_factor_net,
@@ -223,7 +217,6 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
         moment_net.load_state_dict(best_moment_state)
 
         for phase_epoch in range(1, self.config.n_epochs_cond + 1):
-            sdf_epoch += 1
             stochastic_discount_factor_net.train()
             moment_net.eval()
             weights, _ = stochastic_discount_factor_net(
@@ -243,14 +236,14 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
             sharpe = nn.compute_sharpe(stochastic_discount_factor_values)
             history.append(
                 {
-                    "epoch": float(sdf_epoch),
+                    "epoch": float(phase_epoch),
                     "phase": "conditional",
                     "train_loss": float(loss.item()),
                     "train_sharpe": float(sharpe.item()),
                 }
             )
             self._maybe_store_checkpoint(
-                epoch=sdf_epoch,
+                phase="conditional",
                 phase_epoch=phase_epoch,
                 checkpoint_epochs=checkpoint_epochs,
                 stochastic_discount_factor_net=stochastic_discount_factor_net,
@@ -295,12 +288,13 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
             converged=True,
             train_metrics={
                 "n_train_periods": float(batch.n_periods),
-                "n_checkpoints": float(len(checkpoint_epochs)),
+                "n_checkpoints": float(len(self.available_checkpoints)),
             },
-            best_epoch=select_checkpoint_epoch(
+            best_epoch=_select_checkpoint(
                 checkpoint=None,
                 configured_default=self.config.default_checkpoint,
-                available=checkpoint_epochs,
+                available=self.available_checkpoints,
+                n_epochs_unc=self.config.n_epochs_unc,
             ),
             history=self._history,
             notes=(
@@ -312,7 +306,7 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
         self,
         batch: CrossSectionBatch,
         *,
-        checkpoint: int | None = None,
+        checkpoint: SDFCheckpoint | int | None = None,
     ) -> StochasticDiscountFactorState:
         if not self.is_fitted or self._n_characteristics is None or not self._checkpoint_states:
             raise RuntimeError("StochasticDiscountFactorModel must be fitted before extract()")
@@ -335,10 +329,11 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
         torch = import_torch()
         nn = _import_stochastic_discount_factor_nn()
         device = resolve_device(torch, self.config.device)
-        selected_checkpoint = select_checkpoint_epoch(
+        selected_checkpoint = _select_checkpoint(
             checkpoint=checkpoint,
             configured_default=self.config.default_checkpoint,
             available=self.available_checkpoints,
+            n_epochs_unc=self.config.n_epochs_unc,
         )
         checkpoint_state = self._checkpoint_states[selected_checkpoint]
 
@@ -404,18 +399,15 @@ class StochasticDiscountFactorModel(BaseStochasticDiscountFactorModel):
     def _maybe_store_checkpoint(
         self,
         *,
-        epoch: int,
+        phase: str,
         phase_epoch: int,
         checkpoint_epochs: tuple[int, ...],
         stochastic_discount_factor_net: Any,
         moment_net: Any,
     ) -> None:
-        # Burn-in is phase-local (CPZ uses a per-phase `ignoreEpoch`); the
-        # storage key remains the global epoch so the positive checkpoint grid
-        # is unique across phases.
-        if phase_epoch <= self.config.burn_in_epochs or epoch not in checkpoint_epochs:
+        if phase_epoch <= self.config.burn_in_epochs or phase_epoch not in checkpoint_epochs:
             return
-        self._checkpoint_states[epoch] = _capture_state(
+        self._checkpoint_states[(phase, phase_epoch)] = _capture_state(
             stochastic_discount_factor_net, moment_net
         )
 
@@ -445,11 +437,69 @@ def _reshape_weight_panel(
     return panel
 
 
+def _checkpoint_sort_key(checkpoint: SDFCheckpoint) -> tuple[int, int]:
+    phase, epoch = checkpoint
+    phase_order = 0 if phase == "unconditional" else 1
+    return phase_order, epoch
+
+
+def _select_checkpoint(
+    *,
+    checkpoint: SDFCheckpoint | int | None,
+    configured_default: SDFCheckpoint | int | None,
+    available: tuple[SDFCheckpoint, ...],
+    n_epochs_unc: int,
+) -> SDFCheckpoint:
+    if not available:
+        raise ValueError("available_checkpoints is empty")
+    legacy_lookup = _legacy_checkpoint_lookup(available, n_epochs_unc=n_epochs_unc)
+    selected = checkpoint if checkpoint is not None else configured_default
+    if selected is not None:
+        if isinstance(selected, tuple):
+            if selected not in available:
+                raise ValueError(
+                    f"checkpoint={selected!r} is not in available_checkpoints={available}"
+                )
+            return selected
+        if int(selected) not in legacy_lookup:
+            raise ValueError(f"checkpoint={selected!r} is not in available_checkpoints={available}")
+        return legacy_lookup[int(selected)]
+
+    positive = [key for key in available if key[1] > 0]
+    return positive[-1] if positive else available[-1]
+
+
+def _legacy_checkpoint_lookup(
+    available: tuple[SDFCheckpoint, ...],
+    *,
+    n_epochs_unc: int,
+) -> dict[int, SDFCheckpoint]:
+    lookup: dict[int, SDFCheckpoint] = {}
+    sentinel_aliases = {
+        -4: VAL_BEST_SHARPE_CONDITIONAL,
+        -3: VAL_BEST_LOSS_CONDITIONAL,
+        -2: VAL_BEST_SHARPE_UNCONDITIONAL,
+        -1: VAL_BEST_LOSS_UNCONDITIONAL,
+    }
+    for legacy, key in sentinel_aliases.items():
+        if key in available:
+            lookup[legacy] = key
+    for key in available:
+        phase, phase_epoch = key
+        if phase_epoch <= 0:
+            continue
+        legacy_epoch = phase_epoch if phase == "unconditional" else n_epochs_unc + phase_epoch
+        lookup[legacy_epoch] = key
+    return lookup
+
+
 def _cpu_state_dict(model: Any) -> dict[str, Any]:
     return {key: value.detach().cpu().clone() for key, value in model.state_dict().items()}
 
 
-def _capture_state(stochastic_discount_factor_net: Any, moment_net: Any) -> dict[str, dict[str, Any]]:
+def _capture_state(
+    stochastic_discount_factor_net: Any, moment_net: Any
+) -> dict[str, dict[str, Any]]:
     return {
         "stochastic_discount_factor": _cpu_state_dict(stochastic_discount_factor_net),
         "moment": _cpu_state_dict(moment_net),
@@ -461,6 +511,8 @@ def _prepare_sdf_tensors(batch: CrossSectionBatch, torch: Any, device: Any) -> t
     mask = _resolve_mask(batch, torch, device)
     returns = torch.where(mask, returns_raw, torch.zeros_like(returns_raw))
     n_obs_per_asset = mask.float().sum(dim=0)
+    if int(mask.sum().item()) == 0:
+        raise ValueError("validation_batch contains no valid SDF validation observations")
     asset_features = torch.as_tensor(
         np.asarray(batch.characteristics, dtype=np.float32), dtype=torch.float32, device=device
     )

--- a/src/ml4t/models/types.py
+++ b/src/ml4t/models/types.py
@@ -222,7 +222,7 @@ class FitSummary:
     converged: bool
     train_metrics: dict[str, float] = field(default_factory=dict)
     val_metrics: dict[str, float] = field(default_factory=dict)
-    best_epoch: int | None = None
+    best_epoch: Any | None = None
     history: tuple[dict[str, float | str], ...] = ()
     notes: tuple[str, ...] = ()
 
@@ -356,7 +356,7 @@ class StochasticDiscountFactorState:
 
     asset_weights: Array2D
     sdf_values: FloatArray1D | None = None
-    checkpoint_epoch: int | None = None
+    checkpoint_epoch: Any | None = None
     timestamps: tuple[Any, ...] = ()
     asset_ids: tuple[str, ...] = ()
     metadata: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_cae.py
+++ b/tests/test_cae.py
@@ -4,8 +4,9 @@ import numpy as np
 import pytest
 
 from ml4t.models import CAEConfig, CAEModel, CrossSectionBatch
+from ml4t.models._internal import cae_nn
 
-pytest.importorskip("torch")
+torch = pytest.importorskip("torch")
 
 
 def test_cae_tracks_available_checkpoints_and_supports_checkpointed_extract() -> None:
@@ -64,3 +65,75 @@ def test_cae_classification_requires_continuous_factor_returns() -> None:
     model = CAEModel(CAEConfig(task_type="classification"))
     with pytest.raises(ValueError):
         model.fit(batch)
+
+
+def test_cae_beta_network_uses_batch_norm() -> None:
+    network = cae_nn.BetaNetwork(n_characteristics=4, n_factors=2, hidden_units=(8, 4))
+
+    assert sum(isinstance(module, torch.nn.BatchNorm1d) for module in network.network) == 2
+
+
+def test_cae_validation_batch_stores_default_val_best_checkpoint() -> None:
+    rng = np.random.default_rng(7)
+    n_periods = 8
+    n_assets = 6
+    n_features = 3
+    characteristics = rng.normal(size=(n_periods, n_assets, n_features))
+    returns = 0.05 * characteristics[..., 0] + 0.01 * rng.normal(size=(n_periods, n_assets))
+    train = CrossSectionBatch(
+        characteristics=characteristics,
+        returns=returns,
+        timestamps=tuple(f"2024-{month:02d}" for month in range(1, n_periods + 1)),
+    )
+    val = CrossSectionBatch(
+        characteristics=rng.normal(size=(4, n_assets, n_features)),
+        returns=rng.normal(scale=0.01, size=(4, n_assets)),
+        timestamps=("2024-09", "2024-10", "2024-11", "2024-12"),
+    )
+
+    model = CAEModel(
+        CAEConfig(
+            n_factors=1,
+            hidden_units=(4,),
+            n_epochs=6,
+            checkpoint_interval=3,
+            n_ensemble=1,
+            batch_size=8,
+            lr=1e-2,
+        )
+    )
+    fit = model.fit(train, validation_batch=val, patience=2)
+    state = model.extract(val)
+
+    assert 0 in model.available_checkpoints
+    assert fit.best_epoch == 0
+    assert fit.val_metrics["best_val_loss"] >= 0.0
+    assert state.checkpoint_epoch == 0
+    assert state.asset_betas.shape == (4, n_assets, 1)
+
+
+def test_cae_extract_per_member_returns_member_states() -> None:
+    rng = np.random.default_rng(9)
+    n_periods = 6
+    n_assets = 5
+    n_features = 2
+    characteristics = rng.normal(size=(n_periods, n_assets, n_features))
+    returns = 0.02 * characteristics[..., 0] + 0.01 * rng.normal(size=(n_periods, n_assets))
+    batch = CrossSectionBatch(characteristics=characteristics, returns=returns)
+
+    model = CAEModel(
+        CAEConfig(
+            n_factors=1,
+            hidden_units=(),
+            n_epochs=4,
+            checkpoint_interval=4,
+            n_ensemble=2,
+            lr=1e-2,
+        )
+    )
+    model.fit(batch)
+    states = model.extract_per_member(batch, checkpoint=4)
+
+    assert len(states) == 2
+    assert all(state.asset_betas.shape == (n_periods, n_assets, 1) for state in states)
+    assert [state.metadata["ensemble_member"] for state in states] == [0, 1]

--- a/tests/test_ipca_normalization.py
+++ b/tests/test_ipca_normalization.py
@@ -1,10 +1,4 @@
-"""Unit tests pinning KPS-faithful ΘY normalization in IPCA.
-
-Tests cover the post-fit identification block added in 2026-05-22 (FIX_SPEC_IPCA
-Phase B1, Diffs 1 + 2). The normalization is a rotation of (Γ, f_t) at fixed
-fit residuals, so predictions are unchanged at the ridge defaults
-`gamma_ridge = factor_ridge = 1e-6`.
-"""
+"""Unit tests pinning KPS-faithful ΘY normalization in IPCA."""
 
 from __future__ import annotations
 
@@ -53,9 +47,7 @@ def test_factor_covariance_is_diagonal_descending() -> None:
     np.testing.assert_allclose(off_diag, 0.0, atol=1e-8)
 
     diag = np.diag(f_cov)
-    assert np.all(np.diff(diag) <= 1e-10), (
-        f"factor variances must be descending; got diag={diag}"
-    )
+    assert np.all(np.diff(diag) <= 1e-10), f"factor variances must be descending; got diag={diag}"
     assert np.all(diag >= -1e-12), f"factor variances must be non-negative; got diag={diag}"
 
 
@@ -86,9 +78,7 @@ def test_extract_predictions_match_unnormalized_at_default_ridge() -> None:
     model.fit(batch)
     state = model.extract(batch)
 
-    reconstructed = np.einsum(
-        "tnk,tk->tn", state.asset_betas, state.factor_returns, optimize=True
-    )
+    reconstructed = np.einsum("tnk,tk->tn", state.asset_betas, state.factor_returns, optimize=True)
     valid = np.isfinite(reconstructed) & np.isfinite(batch.returns)
     # Per KPS, fit minimizes Σ (r - Z Γ f)². At default ridge the residual is
     # small and is the same as the un-normalized fit would deliver.
@@ -123,8 +113,7 @@ def test_normalize_theta_y_sign_convention_deterministic() -> None:
     for k in range(gamma_norm.shape[1]):
         argmax = int(np.argmax(np.abs(gamma_norm[:, k])))
         assert gamma_norm[argmax, k] >= 0.0, (
-            f"column {k}: max-magnitude entry must be non-negative; got "
-            f"{gamma_norm[argmax, k]}"
+            f"column {k}: max-magnitude entry must be non-negative; got {gamma_norm[argmax, k]}"
         )
 
 

--- a/tests/test_stochastic_discount_factor.py
+++ b/tests/test_stochastic_discount_factor.py
@@ -57,19 +57,24 @@ def test_stochastic_discount_factor_extracts_weight_state_and_linear_mapping() -
         )
     )
     fit = model.fit(train)
-    train_state = model.extract(train, checkpoint=2)
-    future_state = model.extract(future, checkpoint=8)
+    train_state = model.extract(train, checkpoint=("unconditional", 2))
+    future_state = model.extract(future, checkpoint=("conditional", 4))
 
     mapper = LinearStochasticDiscountFactorReturnMapper()
     mapper_fit = mapper.fit(train_state, train)
     forecast = mapper.predict(future_state)
 
     assert fit.converged
-    assert model.available_checkpoints == (2, 4, 6, 8)
-    assert train_state.checkpoint_epoch == 2
+    assert model.available_checkpoints == (
+        ("unconditional", 2),
+        ("unconditional", 4),
+        ("conditional", 2),
+        ("conditional", 4),
+    )
+    assert train_state.checkpoint_epoch == ("unconditional", 2)
     assert train_state.sdf_values is not None
     assert train_state.asset_weights.shape == (n_periods, n_assets)
-    assert future_state.checkpoint_epoch == 8
+    assert future_state.checkpoint_epoch == ("conditional", 4)
     assert future_state.sdf_values is None
     assert future_state.asset_weights.shape == (3, n_assets)
     assert mapper_fit.converged
@@ -116,7 +121,7 @@ def test_stochastic_discount_factor_beta_head_returns_signals() -> None:
         )
     )
     model.fit(train)
-    train_state = model.extract(train, checkpoint=8)
+    train_state = model.extract(train, checkpoint=("conditional", 4))
 
     head = StochasticDiscountFactorBetaNetworkHead(model.config)
     fit = head.fit(train_state, train, validation_state=train_state, validation_batch=train)
@@ -130,7 +135,9 @@ def test_stochastic_discount_factor_beta_head_returns_signals() -> None:
     assert np.isfinite(signal.signal_values).any()
 
 
-def _sdf_batch(seed: int, n_periods: int = 8, n_assets: int = 6, n_features: int = 3) -> CrossSectionBatch:
+def _sdf_batch(
+    seed: int, n_periods: int = 8, n_assets: int = 6, n_features: int = 3
+) -> CrossSectionBatch:
     rng = np.random.default_rng(seed)
     characteristics = rng.normal(size=(n_periods, n_assets, n_features))
     signal = 0.4 * characteristics[..., 0] - 0.2 * characteristics[..., 1]
@@ -160,13 +167,16 @@ def test_phase_local_burn_in_resets_between_phases() -> None:
         )
     )
     model.fit(_sdf_batch(seed=1))
-    # Phase 1 global epochs 1-5: skip phase_epoch 1-3 -> keep 4, 5.
-    # Phase 3 global epochs 6-10 (phase_epoch 1-5): skip phase_epoch 1-3 -> keep 9, 10.
-    assert model.available_checkpoints == (4, 5, 9, 10)
-    # A global counter would have kept 6, 7, 8 (all > 3); phase-local burn-in drops them.
-    assert 6 not in model.available_checkpoints
-    assert 7 not in model.available_checkpoints
-    assert 8 not in model.available_checkpoints
+    # Each SDF training phase uses its own epoch index for burn-in and checkpoints.
+    assert model.available_checkpoints == (
+        ("unconditional", 4),
+        ("unconditional", 5),
+        ("conditional", 4),
+        ("conditional", 5),
+    )
+    assert ("conditional", 1) not in model.available_checkpoints
+    assert ("conditional", 2) not in model.available_checkpoints
+    assert ("conditional", 3) not in model.available_checkpoints
 
 
 def test_validation_best_checkpoints_tracked() -> None:
@@ -211,7 +221,7 @@ def test_validation_best_checkpoints_tracked() -> None:
 
     # Default extraction (no checkpoint) still selects a positive epoch, not a sentinel.
     default_state = model.extract(train)
-    assert default_state.checkpoint_epoch > 0
+    assert default_state.checkpoint_epoch == ("conditional", 6)
 
 
 def test_validation_batch_requires_returns() -> None:


### PR DESCRIPTION
## Summary

Aligns the library latent-factor training protocols with the Chapter 14 audit conclusions:

- adds CAE shuffled mini-batch training, hidden-layer BatchNorm, validation-loss best checkpointing, and per-member extraction
- makes SDF checkpoints phase-qualified, tracks validation-best states by phase, and preserves legacy integer checkpoint lookup where needed
- keeps IPCA KPS ThetaY normalization and final-gamma factor consistency cleanly documented without audit-era comments

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run ty check`
- `uv run pytest tests -q`
- `uv build`

Book-side bridge validation was run against this local source via `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src` because the current PyPI alpha predates these API changes.
