### PR TITLE
0.1.0b0 - Beta Readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,26 @@ jobs:
       - name: Run ty check
         run: uv run ty check
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync --dev --extra docs
+
+      - name: Build docs
+        run: uv run mkdocs build --strict
+
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -158,7 +178,7 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test, test-package-smoke, mps-smoke]
+    needs: [lint, typecheck, docs, test, test-package-smoke, mps-smoke]
     steps:
       - uses: actions/checkout@v6.0.3
         with:

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -71,6 +71,11 @@ The package root re-exports the main model classes, configs, batches, results, a
         - PortfolioAllocationPipeline
         - PortfolioPipelineFitResult
 
+## Stability
+
+The [API Stability](../reference/api-stability.md) page defines the public
+surface intended to remain stable through the `0.1` beta series.
+
 ## Integration
 
 ::: ml4t.models.integration
@@ -87,4 +92,3 @@ The package root re-exports the main model classes, configs, batches, results, a
 | `ml4t.models.stochastic_discount_factor` | weight-native SDF estimation and return projections |
 | `ml4t.models.asset_prediction` | direct asset-level predictors |
 | `ml4t.models.portfolio` | end-to-end portfolio learners |
-

--- a/docs/book-guide/index.md
+++ b/docs/book-guide/index.md
@@ -73,6 +73,25 @@ The case studies are intended to act as:
 
 They should not define the public API by accident.
 
+## Compatibility Status
+
+The `0.1.0b0` beta line is validated against the Chapter 14 teaching flow and the shared
+case-study latent-factor bridge.
+
+| Book surface | Validation status |
+|---|---|
+| `14_latent_factors/04_ipca.ipynb` | full notebook execution passed |
+| `14_latent_factors/05_rp_pca.ipynb` | full notebook execution passed |
+| `14_latent_factors/06_conditional_autoencoder.ipynb` | full notebook execution passed |
+| `14_latent_factors/07_stochastic_discount_factor.ipynb` | full notebook execution passed |
+| `14_latent_factors/08_supervised_autoencoder.ipynb` | Papermill smoke execution passed; full production training is long-running |
+| `14_latent_factors/09_case_study_insights.ipynb` | full notebook execution passed |
+| `case_studies.utils.latent_factors.library_bridge` | synthetic PCA, IPCA, CAE, SAE, and SDF bridge smoke checks passed |
+
+The teaching notebooks keep hand-built implementations where that improves exposition. The
+case-study path uses `ml4t-models` through the shared latent-factor bridge so the same
+contracts are exercised in walk-forward validation and registry-backed analysis.
+
 ## Recommended Reading Order
 
 If you are moving from the book notebooks to the library:

--- a/docs/book-guide/index.md
+++ b/docs/book-guide/index.md
@@ -92,6 +92,35 @@ The teaching notebooks keep hand-built implementations where that improves expos
 case-study path uses `ml4t-models` through the shared latent-factor bridge so the same
 contracts are exercised in walk-forward validation and registry-backed analysis.
 
+## Case-Study Validation
+
+The beta gate also checks that each case-study family can execute its model-specific
+latent-factor notebooks through the shared bridge.
+
+| Case study | Validation status |
+|---|---|
+| ETF returns | PCA, IPCA, SDF, and SAE cached executions passed; CAE passed in cached three-fold validation mode |
+| US firm characteristics | IPCA, CAE, SDF, and SAE passed in cached three-fold validation mode |
+| S&P 500 option analytics | PCA, IPCA, CAE, SDF, and SAE passed in cached three-fold validation mode |
+
+The ETF CAE notebook also reached the cached full-fold execution path and loaded the
+registry-backed model outputs before the notebook kernel exited while processing the large
+cached result set. The three-fold validation run exercises the same library bridge,
+checkpoint handling, prediction schema, and registry persistence path with a bounded
+runtime footprint.
+
+## Evaluation Boundary
+
+Case-study IC reporting is delegated to `ml4t-diagnostic`:
+
+- fold-level scoring calls `ml4t.diagnostic.metrics.cross_sectional_ic`
+- pooled model-analysis summaries call `cross_sectional_ic` and `cross_sectional_ic_series`
+- model outputs are converted into `PredictionsFrame`, `SignalsFrame`, `WeightsFrame`, and
+  `ml4t-backtest` handoff payloads by library adapters
+
+`ml4t-models` remains responsible for fitting and output contracts. Statistical diagnostics
+and execution simulation remain owned by `ml4t-diagnostic` and `ml4t-backtest`.
+
 ## Recommended Reading Order
 
 If you are moving from the book notebooks to the library:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -6,6 +6,9 @@ This quickstart shows the three main workflows in the library:
 2. stochastic discount factor extraction
 3. end-to-end portfolio learning
 
+The same workflows are available as executable smoke examples in the repository's
+`examples/` directory.
+
 ## 1. Latent-Factor Forecasting
 
 The latent-factor path is intentionally three-stage:

--- a/docs/reference/api-stability.md
+++ b/docs/reference/api-stability.md
@@ -1,0 +1,72 @@
+# API Stability
+
+This page defines the public surface that is intended to be stable for the
+`0.1` beta series.
+
+## Stable Import Surface
+
+Use these modules in notebooks, examples, and downstream libraries:
+
+| Surface | Purpose |
+|---|---|
+| `ml4t.models` | convenience imports for reader-facing workflows |
+| `ml4t.models.api` | structural protocols for model families |
+| `ml4t.models.types` | batch, state, prediction, and frame contracts |
+| `ml4t.models.configs` | frozen dataclass configs |
+| `ml4t.models.integration` | adapters for long frames, diagnostics, and backtests |
+
+The package root re-exports the core model classes, configs, result contracts,
+and integration helpers used throughout the documentation.
+
+## Stable Families
+
+The beta API is organized around four model families:
+
+| Family | Stable models |
+|---|---|
+| Latent factors | `PCAModel`, `RPPCAModel`, `IPCAModel`, `CAEModel` |
+| Stochastic discount factor | `StochasticDiscountFactorModel` |
+| Direct asset prediction | `SAEModel` |
+| Portfolio learning | `LinearFeaturePortfolioModel`, `LSTMPortfolioModel`, `DeepPortfolioModel` |
+
+Each family keeps its own contract because the native object differs by model:
+latent-factor state, SDF weights, direct signals, or portfolio weights.
+
+## Naming Conventions
+
+Reader-facing result names describe the object they carry:
+
+| Name | Object |
+|---|---|
+| `AssetForecastResult` | expected returns by timestamp and asset |
+| `AssetSignalResult` | direct asset-level scores or signals |
+| `AssetWeightsResult` | cross-sectional SDF or asset weights |
+| `PortfolioWeightsResult` | sequence-model portfolio allocations |
+| `PredictionsFrame` | long-format expected-return predictions |
+| `SignalsFrame` | long-format direct signals |
+| `WeightsFrame` | long-format portfolio or asset weights |
+| `ResultsFrame` | common frame protocol implemented by integration outputs |
+
+Avoid names that describe implementation mechanics rather than the financial
+object. If a new public result type is added, it should fit this pattern.
+
+## Extension Points
+
+The following extension points are intentionally public:
+
+- `LatentFactorModel`
+- `FactorForecaster`
+- `AssetMapper`
+- `AssetPredictionModel`
+- `StochasticDiscountFactorEstimator`
+- `PortfolioModel`
+- `PortfolioPostprocessor`
+
+New models should implement the relevant protocol and return the existing result
+contracts before introducing a new public type.
+
+## Deferred Surface
+
+The beta release does not freeze internals under `ml4t.models._internal`.
+Functions and modules prefixed with `_` are implementation details and may change
+between `0.1` releases.

--- a/docs/reference/release-gates.md
+++ b/docs/reference/release-gates.md
@@ -1,0 +1,42 @@
+# Release Gates
+
+This page defines the checks required before tagging a beta or stable release.
+
+## Local Gate
+
+Run the full gate from the repository root:
+
+```bash
+uv run ruff check src/ tests/ examples
+uv run ruff format --check src/ tests/ examples
+uv run ty check
+uv run pytest tests/ -q
+uv run mkdocs build --strict
+uv build
+```
+
+For optional integration paths, also run:
+
+```bash
+uv run --extra integration pytest \
+  tests/test_integration_backtest.py \
+  tests/test_integration_data.py \
+  tests/test_integration_surfaces.py \
+  -q
+```
+
+## GitHub Gate
+
+The main CI workflow must pass before a beta tag is created:
+
+- lint
+- type check
+- docs
+- Python 3.12 tests
+- Python 3.13 tests
+- Python 3.14 tests
+- package smoke test
+- MPS smoke test
+- package build
+
+The release workflow publishes only from `v*` tags after the beta branch has merged.

--- a/docs/user-guide/direct-asset-prediction.md
+++ b/docs/user-guide/direct-asset-prediction.md
@@ -28,9 +28,6 @@ decomposition.
 
 ## Why It Lives Outside Latent Factors
 
-The library originally explored treating `SAE` as another latent-factor model. That turns
-out to be the wrong abstraction.
-
 In the current design:
 
 - `SAEModel` is a direct predictor
@@ -48,6 +45,10 @@ not:
 ```text
 cross-section batch -> factor state -> factor forecaster -> beta × lambda
 ```
+
+| Input contract | Native output | Assumption |
+|---|---|---|
+| `CrossSectionBatch` | `AssetSignalResult` | supervised targets are the object of interest |
 
 ## Checkpoints
 
@@ -81,6 +82,10 @@ with:
 - timestamps
 - asset IDs
 - selected checkpoint metadata
+
+The signal is not automatically calibrated as an expected return. Use the integration
+helpers to convert it to long-format signal frames, then evaluate or transform it in the
+diagnostic and backtest layers.
 
 ## When To Use It
 

--- a/docs/user-guide/integration.md
+++ b/docs/user-guide/integration.md
@@ -36,6 +36,10 @@ These help when your data starts as:
 - a polars frame
 - a long-format table with ML4T-style schema metadata
 
+If `ml4t-specs` is installed, the adapters accept `FeedSpec` objects directly. Without that
+optional dependency, they still accept explicit column names and plain metadata mappings.
+The library does not require users to source data through `ml4t-data`.
+
 ## Frame Adapters
 
 The frame helpers normalize model outputs into standard long-format tables.
@@ -73,6 +77,18 @@ These construct:
 - standardized signal frames
 - optional context frames
 - `FeedSpec`-compatible metadata for `ml4t-backtest`
+
+The handoff payload is intentionally shallow: it prepares frames and metadata, then lets
+`ml4t-backtest` own execution simulation.
+
+## Diagnostics Handoff
+
+`ml4t-models` emits prediction, signal, and weight frames with standard timestamp and asset
+columns. Use those frames as inputs to `ml4t-diagnostic` for cross-sectional IC, portfolio
+diagnostics, tearsheets, and validation reports.
+
+This library does not compute IC summaries or diagnostics itself. Keeping diagnostics in
+`ml4t-diagnostic` prevents model implementations from carrying a second evaluation stack.
 
 ## Artifact Writing
 

--- a/docs/user-guide/latent-factor-models.md
+++ b/docs/user-guide/latent-factor-models.md
@@ -17,12 +17,12 @@ The family splits into two groups:
 
 ## Overview
 
-| Model | Contract | Loading structure | Predictive object |
-|---|---|---|---|
-| `PCAModel` | `PersistentPanelBatch` | static loadings | `beta × premium` after a forecaster |
-| `RPPCAModel` | `PersistentPanelBatch` | static loadings with risk-premium-aware extraction | `beta × premium` after a forecaster |
-| `IPCAModel` | `CrossSectionBatch` | linear characteristic-implied betas | `beta × premium` after a forecaster |
-| `CAEModel` | `CrossSectionBatch` | nonlinear characteristic-implied betas | `beta × premium` after a forecaster |
+| Model | Input contract | Native output | Main assumption | Predictive object |
+|---|---|---|---|---|
+| `PCAModel` | `PersistentPanelBatch` | `LatentFactorState` with static loadings and factor returns | stable asset IDs | `beta × premium` after a forecaster |
+| `RPPCAModel` | `PersistentPanelBatch` | `LatentFactorState` with pricing-aware static loadings | stable asset IDs and meaningful cross-sectional means | `beta × premium` after a forecaster |
+| `IPCAModel` | `CrossSectionBatch` | `LatentFactorState` with characteristic-implied betas | dated characteristics parameterize conditional exposures | `beta × premium` after a forecaster |
+| `CAEModel` | `CrossSectionBatch` | `LatentFactorState` with nonlinear characteristic betas | nonlinear exposure map can be learned from cross-sections | `beta × premium` after a forecaster |
 
 ## PCA
 
@@ -45,6 +45,9 @@ It does not directly forecast expected returns. That requires:
 
 1. a factor-premium forecast
 2. an asset mapper
+
+Do not use PCA when the asset axis is an unstable identifier field. PCA and RP-PCA rely on
+the same entity occupying the same panel slot through time.
 
 ## RP-PCA
 
@@ -74,6 +77,9 @@ Key config fields:
 - `normalize_loadings`
 - `orthogonalize_factors`
 
+The `gamma` parameter in `RPPCAConfig` is the RP-PCA pricing-error weight, not an exposure
+matrix. The fitted loadings are returned in `LatentFactorState.asset_betas`.
+
 ## IPCA
 
 `IPCAModel` is the linear bridge between PCA and neural conditional factor models.
@@ -88,6 +94,7 @@ In the library, `IPCAModel`:
 - consumes `CrossSectionBatch`
 - alternates between factor estimation and gamma estimation
 - returns a `LatentFactorState` with conditional betas and factor history
+- reports ALS convergence metadata in `LatentFactorState.metadata`
 
 The economic interpretation follows
 [Kelly, Pruitt, and Su (2019)](../reference/academic-references.md#ref-kelly-pruitt-su-2019):
@@ -127,6 +134,10 @@ Current implementation features:
 - checkpoint-aware training
 - optional ensemble averaging across saved checkpoints
 - classification mode that still keeps factor construction tied to continuous returns
+
+Checkpoint selection changes the extracted structural state. If you pass
+`checkpoint=10`, the betas and factor history come from the checkpoint saved at epoch 10,
+not from the final training epoch.
 
 This is the right way to think about the model:
 

--- a/docs/user-guide/portfolio-learning.md
+++ b/docs/user-guide/portfolio-learning.md
@@ -12,11 +12,11 @@ This family covers two related ideas:
 
 ## Family Overview
 
-| Model | Style | Native output |
-|---|---|---|
-| `LinearFeaturePortfolioModel` | deterministic baseline | `PortfolioWeightsResult` |
-| `LSTMPortfolioModel` | sequence baseline | `PortfolioWeightsResult` |
-| `DeepPortfolioModel` | structured DeePM-style allocator | `PortfolioWeightsResult` |
+| Model | Input contract | Style | Native output | Main assumption |
+|---|---|---|---|---|
+| `LinearFeaturePortfolioModel` | `PortfolioSequenceBatch` | deterministic baseline | `PortfolioWeightsResult` | pooled feature scores can rank allocation desirability |
+| `LSTMPortfolioModel` | `PortfolioSequenceBatch` | sequence baseline | `PortfolioWeightsResult` | recent feature paths contain allocation-relevant state |
+| `DeepPortfolioModel` | `PortfolioSequenceBatch` | structured DeePM-style allocator | `PortfolioWeightsResult` | temporal, cross-sectional, and graph structure can improve direct allocations |
 
 ## Shared Contract
 
@@ -135,3 +135,7 @@ Current helper:
 
 Use it when you want to transform raw learned weights into a stricter target-weights frame
 before handing them to `ml4t-backtest`.
+
+Postprocessing is deliberately separate from model fitting. This lets the same trained
+allocator be evaluated under different exposure caps, leverage normalization rules, or
+turnover controls.

--- a/docs/user-guide/stochastic-discount-factor.md
+++ b/docs/user-guide/stochastic-discount-factor.md
@@ -21,6 +21,14 @@ The public extracted state is:
 
 - `StochasticDiscountFactorState`
 
+| Input contract | Native output | Primary use | Secondary mapping |
+|---|---|---|---|
+| `CrossSectionBatch` | `StochasticDiscountFactorState` | SDF weights and pricing-kernel series | optional expected-return projection |
+
+`returns` are required for fitting. `characteristics` describe the cross-section used by the
+weight network, and `context_features` can provide date-level state such as macro or market
+features.
+
 ## Why It Is Separate From Latent Factors
 
 Latent-factor models estimate:
@@ -85,6 +93,10 @@ Current helpers include:
 
 These are downstream transformations. They do not change the fact that the core estimator is
 weight-native.
+
+The linear mapper is a transparent baseline. The beta-network head is the flexible option
+when a nonlinear relation between SDF weights, characteristics, and return projections is
+useful for comparison or downstream ranking.
 
 The beta-network head is useful when you need an expected-return-like object for comparison
 with latent-factor studies, ranking experiments, or downstream backtests that expect asset

--- a/examples/direct_asset_prediction.py
+++ b/examples/direct_asset_prediction.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ml4t.models import CrossSectionBatch, SAEConfig, SAEModel
+
+rng = np.random.default_rng(3)
+n_periods, n_assets, n_features = 6, 6, 4
+characteristics = rng.normal(size=(n_periods, n_assets, n_features))
+returns = characteristics[..., 0] - 0.5 * characteristics[..., 1]
+returns += 0.05 * rng.normal(size=returns.shape)
+
+batch = CrossSectionBatch(
+    characteristics=characteristics,
+    returns=returns,
+    timestamps=tuple(f"2024-{idx:02d}" for idx in range(1, n_periods + 1)),
+    asset_ids=tuple(f"asset_{idx}" for idx in range(n_assets)),
+)
+model = SAEModel(
+    SAEConfig(
+        bottleneck_dim=4,
+        aux_hidden_dim=4,
+        main_hidden_units=(8, 8, 8, 8),
+        dropout_rates=(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+        n_epochs=2,
+        checkpoint_interval=2,
+        batch_size=8,
+        device="cpu",
+    )
+)
+fit_result = model.fit(batch, validation_batch=batch)
+signals = model.predict(batch)
+
+assert fit_result.converged
+assert signals.signal_values.shape == (n_periods, n_assets)

--- a/examples/latent_factor_pipeline.py
+++ b/examples/latent_factor_pipeline.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ml4t.models import (
+    BetaLambdaMapper,
+    ExpandingMeanFactorForecaster,
+    LatentFactorForecastPipeline,
+    PCAConfig,
+    PCAModel,
+    PersistentPanelBatch,
+)
+
+rng = np.random.default_rng(1)
+returns = rng.normal(scale=0.02, size=(12, 6))
+asset_ids = tuple(f"asset_{idx}" for idx in range(returns.shape[1]))
+
+train = PersistentPanelBatch(
+    returns=returns,
+    timestamps=tuple(f"2024-{idx:02d}" for idx in range(1, returns.shape[0] + 1)),
+    asset_ids=asset_ids,
+)
+future = PersistentPanelBatch(
+    timestamps=("2025-01", "2025-02"),
+    asset_ids=asset_ids,
+)
+
+pipeline = LatentFactorForecastPipeline(
+    model=PCAModel(PCAConfig(n_factors=2)),
+    forecaster=ExpandingMeanFactorForecaster(),
+    mapper=BetaLambdaMapper(),
+)
+fit_result = pipeline.fit(train)
+prediction = pipeline.predict(future)
+
+assert fit_result.structural_fit.converged
+assert prediction.asset_forecast.expected_returns.shape == (2, 6)

--- a/examples/portfolio_learning.py
+++ b/examples/portfolio_learning.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ml4t.models import (
+    LinearFeaturePortfolioModel,
+    LinearPortfolioConfig,
+    PortfolioAllocationPipeline,
+    PortfolioSequenceBatch,
+    WeightConstraintPostprocessor,
+)
+
+rng = np.random.default_rng(4)
+n_windows, n_periods, n_assets, n_features = 3, 4, 5, 3
+features = rng.normal(size=(n_windows, n_periods, n_assets, n_features))
+returns = 0.03 * features[..., 0] - 0.01 * features[..., 1]
+returns += 0.005 * rng.normal(size=returns.shape)
+
+batch = PortfolioSequenceBatch(
+    features=features,
+    returns=returns,
+    vol_scale=np.ones((n_windows, n_periods, n_assets), dtype=np.float64),
+    mask=np.ones((n_windows, n_periods, n_assets), dtype=bool),
+    asset_ids=tuple(f"asset_{idx}" for idx in range(n_assets)),
+)
+pipeline = PortfolioAllocationPipeline(
+    LinearFeaturePortfolioModel(LinearPortfolioConfig(gross_exposure=1.0)),
+    postprocessors=(WeightConstraintPostprocessor(gross_exposure=0.8),),
+)
+fit_result = pipeline.fit(batch)
+prediction = pipeline.predict(batch)
+
+assert fit_result.model_fit.converged
+assert prediction.processed_weights.weights.shape == (n_windows, n_periods, n_assets)
+assert np.all(np.abs(prediction.processed_weights.weights).sum(axis=-1) <= 0.8 + 1e-8)

--- a/examples/stochastic_discount_factor.py
+++ b/examples/stochastic_discount_factor.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ml4t.models import (
+    CrossSectionBatch,
+    LinearStochasticDiscountFactorReturnMapper,
+    StochasticDiscountFactorConfig,
+    StochasticDiscountFactorModel,
+)
+
+rng = np.random.default_rng(2)
+n_periods, n_assets, n_features = 6, 5, 3
+characteristics = rng.normal(size=(n_periods, n_assets, n_features))
+returns = 0.04 * characteristics[..., 0] - 0.02 * characteristics[..., 1]
+returns += 0.01 * rng.normal(size=returns.shape)
+
+batch = CrossSectionBatch(
+    characteristics=characteristics,
+    returns=returns,
+    timestamps=tuple(f"2024-{idx:02d}" for idx in range(1, n_periods + 1)),
+    asset_ids=tuple(f"asset_{idx}" for idx in range(n_assets)),
+)
+model = StochasticDiscountFactorModel(
+    StochasticDiscountFactorConfig(
+        state_dim_sdf=2,
+        state_dim_moment=4,
+        hidden_dim=8,
+        n_instruments=3,
+        n_epochs_unc=2,
+        n_epochs_moment=1,
+        n_epochs_cond=2,
+        checkpoint_interval=2,
+        dropout=0.0,
+        device="cpu",
+    )
+)
+fit_result = model.fit(batch)
+state = model.extract(batch)
+mapper = LinearStochasticDiscountFactorReturnMapper()
+mapper.fit(state, batch)
+forecast = mapper.predict(state)
+
+assert fit_result.converged
+assert state.asset_weights.shape == (n_periods, n_assets)
+assert forecast.expected_returns.shape == (n_periods, n_assets)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
   - Reference:
     - Architecture: reference/architecture.md
     - API Stability: reference/api-stability.md
+    - Release Gates: reference/release-gates.md
     - Model Families: reference/model-families.md
     - Academic References: reference/academic-references.md
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
     - book-guide/index.md
   - Reference:
     - Architecture: reference/architecture.md
+    - API Stability: reference/api-stability.md
     - Model Families: reference/model-families.md
     - Academic References: reference/academic-references.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
     "quantitative-finance",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Financial and Insurance Industry",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ namespaces = true
 include = [
     "/src",
     "/tests",
+    "/examples",
     "/README.md",
     "/LICENSE",
     "/CHANGELOG.md",

--- a/src/ml4t/models/__init__.py
+++ b/src/ml4t/models/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from importlib import import_module
 
-__version__ = "0.1.0a6"
+__version__ = "0.1.0b0"
 
 from ml4t.models.api import (
     AssetMapper,

--- a/src/ml4t/models/__init__.py
+++ b/src/ml4t/models/__init__.py
@@ -69,6 +69,7 @@ from ml4t.models.latent_factors import CAEModel, IPCAModel, PCAModel, RPPCAModel
 from ml4t.models.mappers import BetaLambdaMapper
 from ml4t.models.pipelines import (
     LatentFactorForecastPipeline,
+    PipelineFitResult,
     PortfolioAllocationPipeline,
     PortfolioPipelineFitResult,
 )
@@ -139,6 +140,7 @@ __all__ = [
     "PCAModel",
     "PersistentPanelBatch",
     "PipelineConfig",
+    "PipelineFitResult",
     "PortfolioAllocationPipeline",
     "PortfolioConfig",
     "PortfolioPipelineFitResult",

--- a/src/ml4t/models/integration/backtest.py
+++ b/src/ml4t/models/integration/backtest.py
@@ -129,6 +129,14 @@ def resolve_feed_spec_mapping(
         if value is not None:
             spec_mapping[key] = value
 
+    if price_col is None:
+        if close_col is not None:
+            spec_mapping["price_col"] = close_col
+        elif spec_mapping.get("price_col") == "close" and spec_mapping.get("close_col") not in (
+            None,
+            "close",
+        ):
+            spec_mapping["price_col"] = spec_mapping["close_col"]
     if "close_col" in spec_mapping and "price_col" not in spec_mapping:
         spec_mapping["price_col"] = spec_mapping["close_col"]
     spec_mapping.setdefault("price_col", "close")

--- a/tests/test_cae.py
+++ b/tests/test_cae.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from ml4t.models import CAEConfig, CAEModel, CrossSectionBatch
+from ml4t.models import (
+    BetaLambdaMapper,
+    CAEConfig,
+    CAEModel,
+    CrossSectionBatch,
+    ExpandingMeanFactorForecaster,
+    LatentFactorForecastPipeline,
+)
 from ml4t.models._internal import cae_nn
 
 torch = pytest.importorskip("torch")
@@ -137,3 +144,49 @@ def test_cae_extract_per_member_returns_member_states() -> None:
     assert len(states) == 2
     assert all(state.asset_betas.shape == (n_periods, n_assets, 1) for state in states)
     assert [state.metadata["ensemble_member"] for state in states] == [0, 1]
+
+
+def test_cae_pipeline_forecasts_returns_through_checkpointed_two_step_path() -> None:
+    rng = np.random.default_rng(13)
+    n_periods = 8
+    n_assets = 7
+    n_features = 3
+    characteristics = rng.normal(size=(n_periods, n_assets, n_features))
+    returns = 0.03 * characteristics[..., 0] - 0.02 * characteristics[..., 1]
+    returns += 0.01 * rng.normal(size=returns.shape)
+    train = CrossSectionBatch(
+        characteristics=characteristics,
+        returns=returns,
+        timestamps=tuple(f"2024-{month:02d}" for month in range(1, n_periods + 1)),
+        asset_ids=tuple(f"A{idx}" for idx in range(n_assets)),
+    )
+    future = CrossSectionBatch(
+        characteristics=rng.normal(size=(3, n_assets, n_features)),
+        timestamps=("2024-09", "2024-10", "2024-11"),
+        asset_ids=tuple(f"A{idx}" for idx in range(n_assets)),
+    )
+    pipeline = LatentFactorForecastPipeline(
+        model=CAEModel(
+            CAEConfig(
+                n_factors=1,
+                hidden_units=(4,),
+                n_epochs=6,
+                checkpoint_interval=3,
+                n_ensemble=1,
+                batch_size=8,
+                lr=1e-2,
+            )
+        ),
+        forecaster=ExpandingMeanFactorForecaster(),
+        mapper=BetaLambdaMapper(),
+    )
+
+    fit = pipeline.fit(train)
+    prediction = pipeline.predict(future, checkpoint=3)
+
+    assert fit.structural_fit.converged
+    assert prediction.state.factor_returns is None
+    assert prediction.state.checkpoint_epoch == 3
+    assert prediction.factor_forecast.factor_premia.shape == (3, 1)
+    assert prediction.asset_forecast.expected_returns.shape == (3, n_assets)
+    assert np.isfinite(prediction.asset_forecast.expected_returns).all()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+EXAMPLES = (
+    "latent_factor_pipeline.py",
+    "stochastic_discount_factor.py",
+    "direct_asset_prediction.py",
+    "portfolio_learning.py",
+)
+
+
+@pytest.mark.parametrize("example", EXAMPLES)
+def test_examples_execute(example: str) -> None:
+    if example in {"stochastic_discount_factor.py", "direct_asset_prediction.py"}:
+        pytest.importorskip("torch")
+    runpy.run_path(str(Path(__file__).parents[1] / "examples" / example))

--- a/tests/test_integration_backtest.py
+++ b/tests/test_integration_backtest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from ml4t.models import (
     AssetForecastResult,
@@ -42,6 +43,32 @@ def test_resolve_feed_spec_mapping_uses_nested_schema_metadata() -> None:
             },
         },
     )
+
+    assert feed_spec["timestamp_col"] == "date"
+    assert feed_spec["entity_col"] == "ticker"
+    assert feed_spec["close_col"] == "settle"
+    assert feed_spec["price_col"] == "settle"
+    assert feed_spec["calendar"] == "NYSE"
+    assert feed_spec["timezone"] == "America/New_York"
+
+
+def test_resolve_feed_spec_mapping_accepts_ml4t_specs_feedspec() -> None:
+    specs = pytest.importorskip("ml4t.specs.market_data")
+
+    frame = {
+        "date": np.array(["2024-01-01", "2024-01-01"], dtype=object),
+        "ticker": np.array(["AAPL", "MSFT"], dtype=object),
+        "settle": np.array([100.0, 200.0], dtype=np.float64),
+    }
+    schema = specs.FeedSpec(
+        timestamp_col="date",
+        entity_col="ticker",
+        close_col="settle",
+        calendar="NYSE",
+        timezone="America/New_York",
+    )
+
+    feed_spec = resolve_feed_spec_mapping(frame, schema=schema)
 
     assert feed_spec["timestamp_col"] == "date"
     assert feed_spec["entity_col"] == "ticker"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import ml4t.models as models
+
+
+def test_documented_pipeline_fit_result_is_public() -> None:
+    assert models.PipelineFitResult.__module__ == "ml4t.models.pipelines"
+    assert "PipelineFitResult" in models.__all__
+
+
+def test_public_frame_names_use_financial_objects() -> None:
+    assert "PredictionsFrame" in models.__all__
+    assert "SignalsFrame" in models.__all__
+    assert "WeightsFrame" in models.__all__
+    assert "ResultsFrame" in models.__all__
+    assert "SurfaceFrame" not in models.__all__

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import ml4t.models as models
+
+
+def test_public_repo_has_no_tracked_internal_or_generated_artifacts() -> None:
+    assert models.__version__
+    root = Path(__file__).parents[1]
+    output = subprocess.check_output(
+        ["git", "ls-files"],
+        cwd=root,
+        text=True,
+    )
+    tracked_files = output.splitlines()
+    forbidden_fragments = (
+        "/archive/",
+        "/_archive/",
+        ".agents/",
+        ".workspace/",
+        "__pycache__/",
+        ".coverage",
+        ".pytest_cache/",
+        ".ruff_cache/",
+        "dist/",
+        "site/",
+    )
+
+    offenders = [
+        path
+        for path in tracked_files
+        if any(fragment in f"/{path}" for fragment in forbidden_fragments)
+    ]
+
+    assert offenders == []
+
+
+def test_readme_ecosystem_image_is_tracked() -> None:
+    root = Path(__file__).parents[1]
+    assert (root / "docs/images/ml4t_ecosystem_workflow_color.png").is_file()


### PR DESCRIPTION
Milestone: `0.1.0b0 - Beta Readiness`

- [x] #13 Audit public API naming and beta-freeze surface
- [x] #14 Promote package metadata from alpha to beta
- [x] #15 Make docs a beta release gate
- [x] #16 Complete reader-facing model documentation
- [x] #17 Add smoke examples for each model family
- [x] #18 Certify sibling-library integration
- [x] #19 Harden high-risk algorithm regression tests
- [x] #20 Clean repo hygiene for public beta
- [x] #21 Run full local and GitHub beta gate
- [ ] #22 Cut and verify v0.1.0b0

Book validation included on this branch:

- [x] #23 Run Chapter 14 teaching notebooks against ml4t-models
- [x] #24 Run latent-factor case-study notebooks
- [x] #25 Validate diagnostics and backtest integration path
- [x] #26 Publish book-facing compatibility note

Local validation:

- `uv run ruff check src/ tests/ examples`
- `uv run ruff format --check src/ tests/ examples`
- `uv run ty check`
- `uv run pytest tests/ -q`
- `uv run mkdocs build --strict`
- `uv build`
- `uv run --extra integration pytest tests/test_integration_backtest.py tests/test_integration_data.py tests/test_integration_surfaces.py -q`
- `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src:/home/stefan/ml4t/code uv run jupyter nbconvert --execute 14_latent_factors/04_ipca.ipynb --to notebook --output /tmp/ml4t_models_beta_04_ipca.ipynb --ExecutePreprocessor.timeout=600`
- `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src:/home/stefan/ml4t/code uv run jupyter nbconvert --execute 14_latent_factors/05_rp_pca.ipynb --to notebook --output /tmp/ml4t_models_beta_05_rp_pca.ipynb --ExecutePreprocessor.timeout=600`
- `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src:/home/stefan/ml4t/code uv run jupyter nbconvert --execute 14_latent_factors/06_conditional_autoencoder.ipynb --to notebook --output /tmp/ml4t_models_beta_06_conditional_autoencoder.ipynb --ExecutePreprocessor.timeout=900`
- `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src:/home/stefan/ml4t/code uv run jupyter nbconvert --execute 14_latent_factors/07_stochastic_discount_factor.ipynb --to notebook --output /tmp/ml4t_models_beta_07_stochastic_discount_factor.ipynb --ExecutePreprocessor.timeout=1200`
- `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src:/home/stefan/ml4t/code uv run papermill 14_latent_factors/08_supervised_autoencoder.ipynb /tmp/ml4t_models_beta_08_supervised_autoencoder_smoke.ipynb -p N_STOCKS 50 -p N_EPOCHS 1 -p N_SPLITS 1 -p START_DATE 2016-01-01 -p END_DATE 2018-12-31`
- `PYTHONPATH=/home/stefan/ml4t/libraries/ml4t-models/src:/home/stefan/ml4t/code uv run jupyter nbconvert --execute 14_latent_factors/09_case_study_insights.ipynb --to notebook --output /tmp/ml4t_models_beta_09_case_study_insights.ipynb --ExecutePreprocessor.timeout=900`
- synthetic bridge smoke for PCA, IPCA, CAE, SAE, and SDF via `case_studies.utils.latent_factors.library_bridge`
- ETF latent-factor notebooks: PCA, IPCA, SDF, and SAE cached executions passed; CAE passed in cached three-fold validation mode
- US firm characteristics latent-factor notebooks: IPCA, CAE, SDF, and SAE passed in cached three-fold validation mode
- S&P 500 option analytics latent-factor notebooks: PCA, IPCA, CAE, SDF, and SAE passed in cached three-fold validation mode

#22 remains open until this PR merges and the `v0.1.0b0` tag publishes successfully.
