### PR TITLE
Fix SDF checkpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ batch = CrossSectionBatch(
 )
 
 model = StochasticDiscountFactorModel(
-    StochasticDiscountFactorConfig(checkpoint_epochs=(256, 512, 768, 1024, 1280))
+    StochasticDiscountFactorConfig(checkpoint_epochs=(256, 512, 768, 1024))
 )
 model.fit(batch)
 state = model.extract(batch, checkpoint=1280)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -81,8 +81,8 @@ batch = CrossSectionBatch(
 )
 
 config = StochasticDiscountFactorConfig(
-    checkpoint_epochs=(256, 512, 768, 1024, 1280),
-    default_checkpoint=1280,
+    checkpoint_epochs=(256, 512, 768, 1024),
+    default_checkpoint=("conditional", 1024),
 )
 model = StochasticDiscountFactorModel(config)
 fit_summary = model.fit(batch)

--- a/docs/user-guide/stochastic-discount-factor.md
+++ b/docs/user-guide/stochastic-discount-factor.md
@@ -114,8 +114,8 @@ from ml4t.models import (
 
 model = StochasticDiscountFactorModel(
     StochasticDiscountFactorConfig(
-        checkpoint_epochs=(256, 512, 768, 1024, 1280),
-        default_checkpoint=1280,
+        checkpoint_epochs=(256, 512, 768, 1024),
+        default_checkpoint=("conditional", 1024),
     )
 )
 

--- a/scripts/ci/test_wheel.py
+++ b/scripts/ci/test_wheel.py
@@ -141,6 +141,8 @@ def test_wheel(candidate_dir: Path, python_version: str, mode: str) -> None:
 
         shutil.copytree("tests", root / "tests")
         shutil.copytree("examples", root / "examples")
+        shutil.copy2("README.md", root / "README.md")
+        shutil.copytree("docs", root / "docs")
         if mode == "full":
             selected_tests = [str(root / "tests")]
             ignored = [

--- a/scripts/ci/test_wheel.py
+++ b/scripts/ci/test_wheel.py
@@ -16,6 +16,12 @@ CORE_TESTS = (
     "test_types.py",
 )
 
+DOCUMENTATION_TEST_INPUTS = (
+    Path("README.md"),
+    Path("docs/getting-started/quickstart.md"),
+    Path("docs/user-guide/stochastic-discount-factor.md"),
+)
+
 
 def _python_executable(venv: Path) -> Path:
     if os.name == "nt":
@@ -141,8 +147,10 @@ def test_wheel(candidate_dir: Path, python_version: str, mode: str) -> None:
 
         shutil.copytree("tests", root / "tests")
         shutil.copytree("examples", root / "examples")
-        shutil.copy2("README.md", root / "README.md")
-        shutil.copytree("docs", root / "docs")
+        for source in DOCUMENTATION_TEST_INPUTS:
+            destination = root / source
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
         if mode == "full":
             selected_tests = [str(root / "tests")]
             ignored = [

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,12 @@ EXAMPLES = (
     "portfolio_learning.py",
 )
 
+DOCUMENTS = (
+    "README.md",
+    "docs/getting-started/quickstart.md",
+    "docs/user-guide/stochastic-discount-factor.md",
+)
+
 
 @pytest.mark.parametrize("example", EXAMPLES)
 def test_examples_execute(example: str) -> None:
@@ -24,15 +30,12 @@ def test_examples_execute(example: str) -> None:
 
 @pytest.mark.parametrize(
     "document",
-    (
-        "README.md",
-        "docs/getting-started/quickstart.md",
-        "docs/user-guide/stochastic-discount-factor.md",
-    ),
+    DOCUMENTS,
 )
 def test_documented_sdf_checkpoint_configs_are_valid(document: str) -> None:
     root = Path(__file__).parents[1]
-    code_blocks = re.findall(r"```python\n(.*?)```", (root / document).read_text(), re.DOTALL)
+    content = (root / document).read_text(encoding="utf-8")
+    code_blocks = re.findall(r"```python\r?\n(.*?)```", content, re.DOTALL)
     checked = 0
     for code_block in code_blocks:
         tree = ast.parse(code_block)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import ast
+import re
 import runpy
 from pathlib import Path
 
 import pytest
+
+from ml4t.models import StochasticDiscountFactorConfig
 
 EXAMPLES = (
     "latent_factor_pipeline.py",
@@ -16,3 +20,36 @@ EXAMPLES = (
 @pytest.mark.parametrize("example", EXAMPLES)
 def test_examples_execute(example: str) -> None:
     runpy.run_path(str(Path(__file__).parents[1] / "examples" / example))
+
+
+@pytest.mark.parametrize(
+    "document",
+    (
+        "README.md",
+        "docs/getting-started/quickstart.md",
+        "docs/user-guide/stochastic-discount-factor.md",
+    ),
+)
+def test_documented_sdf_checkpoint_configs_are_valid(document: str) -> None:
+    root = Path(__file__).parents[1]
+    code_blocks = re.findall(r"```python\n(.*?)```", (root / document).read_text(), re.DOTALL)
+    checked = 0
+    for code_block in code_blocks:
+        tree = ast.parse(code_block)
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            if (
+                not isinstance(call.func, ast.Name)
+                or call.func.id != "StochasticDiscountFactorConfig"
+            ):
+                continue
+            keywords = {
+                keyword.arg: ast.literal_eval(keyword.value)
+                for keyword in call.keywords
+                if keyword.arg
+                in {"checkpoint_epochs", "default_checkpoint", "n_epochs_unc", "n_epochs_cond"}
+            }
+            if not keywords:
+                continue
+            StochasticDiscountFactorConfig(**keywords)
+            checked += 1
+    assert checked > 0


### PR DESCRIPTION
## What changed

- correct the documented SDF phase checkpoint schedule
- use the phase-aware final conditional checkpoint as the configured default
- execute every documented SDF checkpoint configuration in the test suite

## Why

The stable validator correctly rejects conditional checkpoint epochs above `n_epochs_cond=1024`, but three published examples included `1280` as a conditional phase epoch and configured default. The cumulative legacy label `1280` remains valid when selecting an already fitted checkpoint.

## Validation

- 407 tests passed
- Ruff check and format passed
- `ty check` passed
- strict MkDocs build passed
- affected SDF, config, and example tests passed
