### PR TITLE
Harden documentation deployment verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,38 +165,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.identity.outputs.version }}
           RELEASE_COMMIT: ${{ github.sha }}
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          import time
-          from urllib.error import URLError
-          from urllib.request import urlopen
-
-          expected = {
-              "commit": os.environ["RELEASE_COMMIT"],
-              "version": os.environ["RELEASE_VERSION"],
-          }
-          urls = (
-              "https://ml4trading.io/docs/models/release.json",
-              f"https://ml4trading.io/docs/models/releases/{expected['version']}/release.json",
-          )
-          for attempt in range(20):
-              try:
-                  observed = []
-                  for url in urls:
-                      with urlopen(f"{url}?commit={expected['commit']}", timeout=20) as response:
-                          observed.append(json.load(response))
-                  if all(value == expected for value in observed):
-                      break
-              except (OSError, URLError, ValueError):
-                  pass
-              if attempt == 19:
-                  raise RuntimeError(
-                      f"deployed documentation identity did not match {expected!r}"
-                  )
-              time.sleep(15)
-          PY
+        run: uv run python scripts/ci/verify_docs_deployment.py
 
   publish:
     name: Publish to PyPI

--- a/scripts/ci/verify_docs_deployment.py
+++ b/scripts/ci/verify_docs_deployment.py
@@ -1,0 +1,70 @@
+"""Verify that public documentation identifies the release being published."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from urllib.error import URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+USER_AGENT = "ml4t-models-release-verifier/1.0"
+
+
+def _read_identity(url: str, commit: str, attempt: int) -> object:
+    query = urlencode({"commit": commit, "attempt": attempt})
+    request = Request(
+        f"{url}?{query}",
+        headers={"User-Agent": USER_AGENT},
+    )
+    with urlopen(request, timeout=20) as response:
+        return json.load(response)
+
+
+def verify(
+    urls: tuple[str, ...],
+    expected: dict[str, str],
+    *,
+    attempts: int = 20,
+    retry_seconds: float = 15,
+) -> None:
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+
+    observed: list[object] = []
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            observed = [_read_identity(url, expected["commit"], attempt) for url in urls]
+            last_error = None
+            if all(value == expected for value in observed):
+                return
+        except (OSError, URLError, ValueError) as error:
+            last_error = error
+
+        if attempt + 1 < attempts:
+            time.sleep(retry_seconds)
+
+    raise RuntimeError(
+        f"deployed documentation identity did not match {expected!r}; "
+        f"last observed {observed!r}; last error {last_error!r}"
+    )
+
+
+def main() -> None:
+    expected = {
+        "commit": os.environ["RELEASE_COMMIT"],
+        "version": os.environ["RELEASE_VERSION"],
+    }
+    verify(
+        (
+            "https://ml4trading.io/docs/models/release.json",
+            f"https://ml4trading.io/docs/models/releases/{expected['version']}/release.json",
+        ),
+        expected,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_release_candidate.py
+++ b/tests/test_release_candidate.py
@@ -4,7 +4,10 @@ import json
 import subprocess
 import tarfile
 import zipfile
+from io import BytesIO
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+from urllib.request import Request
 
 import numpy as np
 import pytest
@@ -15,6 +18,7 @@ from scripts.ci import (
     hardware_qualification,
     performance_qualification,
     test_wheel,
+    verify_docs_deployment,
 )
 
 
@@ -232,4 +236,36 @@ def test_hardware_qualification_separates_replay_and_cpu_recovery_tolerances() -
         cross_backend,
         "cuda",
         cpu_recovery=True,
+    )
+
+
+def test_docs_verifier_identifies_client_and_varies_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = {"commit": "a" * 40, "version": "0.1.0"}
+    responses = iter(({"commit": "old", "version": "0.1.0"}, expected))
+    requests: list[Request] = []
+
+    def open_url(request: Request, *, timeout: int) -> BytesIO:
+        requests.append(request)
+        assert timeout == 20
+        return BytesIO(json.dumps(next(responses)).encode())
+
+    monkeypatch.setattr(verify_docs_deployment, "urlopen", open_url)
+    monkeypatch.setattr(verify_docs_deployment.time, "sleep", lambda _: None)
+
+    verify_docs_deployment.verify(
+        ("https://ml4trading.io/docs/models/release.json",),
+        expected,
+        attempts=2,
+        retry_seconds=0,
+    )
+
+    assert [parse_qs(urlparse(request.full_url).query)["attempt"] for request in requests] == [
+        ["0"],
+        ["1"],
+    ]
+    assert all(
+        request.get_header("User-agent") == verify_docs_deployment.USER_AGENT
+        for request in requests
     )

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -99,6 +99,7 @@ def test_ci_qualifies_one_candidate_across_required_platforms() -> None:
 def test_release_promotes_qualified_candidate_without_rebuilding() -> None:
     root = Path(__file__).parents[1]
     workflow = (root / ".github/workflows/release.yml").read_text(encoding="utf-8")
+    verifier = (root / "scripts/ci/verify_docs_deployment.py").read_text(encoding="utf-8")
 
     assert "uv build" not in workflow
     assert "--workflow ci.yml" in workflow
@@ -106,7 +107,8 @@ def test_release_promotes_qualified_candidate_without_rebuilding() -> None:
     assert "packages-dir: candidate/dist/" in workflow
     assert "name: Publish Qualified Documentation" in workflow
     assert "DOCS_DEPLOY_KEY is required for a stable release" in workflow
-    assert "https://ml4trading.io/docs/models/release.json" in workflow
+    assert "scripts/ci/verify_docs_deployment.py" in workflow
+    assert "https://ml4trading.io/docs/models/release.json" in verifier
     assert "needs: [select-candidate, docs]" in workflow
 
 


### PR DESCRIPTION
## What changed

- move public documentation identity verification into a tested CI script
- send an explicit release-verifier user agent accepted by ml4trading.io
- use a distinct cache-busting query for each retry
- report the last observed payload or request error on failure

## Root cause

The stable release deployed both documentation trees successfully, but Python's default urllib
user agent receives HTTP 403 from ml4trading.io. The inline workflow swallowed that response and
timed out without diagnostics.

## Impact

Stable releases can verify the deployed revision before publishing the already-qualified candidate
to PyPI.

## Validation

- `uv run pytest -q` (408 passed)
- `uv run ruff check` and `uv run ruff format --check` on changed Python files
- `uv run ty check scripts/ci/verify_docs_deployment.py`
- end-to-end verifier request against the deployed 0.1.0 stable and versioned markers
