### PR TITLE
Set repository for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="${{ github.ref_name }}"
-          args=("$tag" --generate-notes candidate/dist/* candidate/candidate.json)
+          args=(
+            "$tag"
+            --repo "${{ github.repository }}"
+            --generate-notes
+            candidate/dist/*
+            candidate/candidate.json
+          )
           if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
             args+=(--prerelease)
           fi

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -110,6 +110,7 @@ def test_release_promotes_qualified_candidate_without_rebuilding() -> None:
     assert "scripts/ci/verify_docs_deployment.py" in workflow
     assert "https://ml4trading.io/docs/models/release.json" in verifier
     assert "needs: [select-candidate, docs]" in workflow
+    assert '--repo "${{ github.repository }}"' in workflow
 
 
 def test_security_policy_has_a_private_reporting_route_and_supported_versions() -> None:


### PR DESCRIPTION
## What changed

- pass the explicit repository to `gh release create`
- assert that the release workflow remains independent of a local Git checkout

## Root cause

The GitHub release job downloads artifacts without checking out the repository. The `gh` command
therefore could not infer a repository and failed after PyPI publishing succeeded.

## Impact

Future tag releases can create the GitHub release and attach the qualified candidate artifacts from
an artifact-only job.

## Validation

- `uv run pytest tests/test_repo_hygiene.py -q` (7 passed)
- pre-commit suite passed, including Ruff, `ty`, and full pytest
- release command shell syntax checked with `bash -n`
