### PR TITLE
release: prepare 0.1.1

### DIFF
--- a/src/ml4t/models/_version.py
+++ b/src/ml4t/models/_version.py
@@ -1,3 +1,3 @@
 """Package version shared by public and internal runtime metadata."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/tests/test_release_candidate.py
+++ b/tests/test_release_candidate.py
@@ -12,6 +12,7 @@ from urllib.request import Request
 import numpy as np
 import pytest
 
+from ml4t.models import __version__
 from scripts.ci import (
     candidate,
     check_performance,
@@ -35,16 +36,16 @@ def test_candidate_manifest_binds_artifacts_to_source_identity(candidate_dir: Pa
         candidate_dir,
         expected_commit="a" * 40,
         expected_tree="b" * 40,
-        expected_tag="v0.1.0",
+        expected_tag=f"v{__version__}",
     )
 
     manifest = json.loads((candidate_dir / "candidate.json").read_text(encoding="utf-8"))
 
     assert manifest["name"] == "ml4t-models"
-    assert manifest["version"] == "0.1.0"
+    assert manifest["version"] == __version__
     assert {record["filename"] for record in manifest["artifacts"]} == {
-        "ml4t_models-0.1.0-py3-none-any.whl",
-        "ml4t_models-0.1.0.tar.gz",
+        f"ml4t_models-{__version__}-py3-none-any.whl",
+        f"ml4t_models-{__version__}.tar.gz",
     }
 
 


### PR DESCRIPTION
Prepare the static public version for the first stable patch release and make the release-candidate contract test independent of a hardcoded old version. The separate wrong-tag test retains mismatch coverage.

Local verification:
- 409 tests pass with 93% coverage
- Ruff, ty, strict MkDocs, package build, isolated wheel import, and pre-commit pass